### PR TITLE
gtest 1.17.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,24 @@
-{% set version = "1.14.0" %}
+{% set name = "gtest" %}
+{% set version = "1.17.0" %}
 
 
 package:
-  name: gtest-split
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
   url: https://github.com/google/googletest/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+  sha256: 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
+    - ninja-base
   host: []  # Empty host dependency section
 
 outputs:
@@ -30,9 +32,10 @@ outputs:
         - {{ pin_subpackage('gtest', max_pin='x.x.x') }}
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
       run_constrained:
         - gmock {{ version }}
     test:
@@ -81,7 +84,7 @@ about:
     This repository is a merger of the formerly separate GoogleTest and
     GoogleMock projects. These were so closely related that it makes sense to
     maintain and release them together.
-  doc_url: https://google.github.io/googletest/
+  doc_url: https://google.github.io/googletest
   dev_url: https://github.com/google/googletest
 
 extra:
@@ -93,3 +96,5 @@ extra:
     - xhochy
     - h-vetinari
   feedstock-name: gtest
+  skip-lints:
+    - patch_unnecessary


### PR DESCRIPTION
gtest 1.17.0 

**Destination channel:** Defaults

### Links

- [PKG-10015]
- dev_url:        https://github.com/google/googletest/tree/v1.17.0
- conda_forge:    https://github.com/conda-forge/gtest-feedstock
- pypi:           https://www.google.com/
- pypi inspector: https://www.google.com/

### Explanation of changes:

- new version number


[PKG-10015]: https://anaconda.atlassian.net/browse/PKG-10015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ